### PR TITLE
feat(loaddata.tsx): user can select validation year

### DIFF
--- a/src/pages/loadData/LoadData.tsx
+++ b/src/pages/loadData/LoadData.tsx
@@ -10,8 +10,12 @@ import {
   StepLabel,
   StepContent,
   Typography,
+  Select,
+  InputLabel,
+  MenuItem,
+  FormControl,
 } from "@mui/material";
-import { FormatListNumbered } from "@mui/icons-material";
+import { ConstructionOutlined, FormatListNumbered } from "@mui/icons-material";
 
 import { Aligner } from "../Pages.styles";
 
@@ -271,6 +275,30 @@ const LoadData = (props: LoadDataPageProps) => {
     return <Tabs headers={headers} bodies={bodies} id="file-upload-tabs" />;
   };
 
+  const RulesetSelect = () => {
+    const [ruleset, setRuleset] = useState("")
+    async function handleRulesetChange(e: { preventDefault: () => void; target: { value: any; }; }) {
+      e.preventDefault();
+      const selectedRuleset = e.target.value;
+      console.log({selectedRuleset});
+    };
+    return(
+      <FormControl fullWidth>
+      <InputLabel id="select-ruleset-label"> Select validation year</InputLabel>
+      <Select
+        labelId="select-ruleset-label"
+        id="select-ruleset"
+        label="Select validation year"
+        onChange={handleRulesetChange}
+        value=""
+      >
+        <MenuItem value={"cin2022_23"}>2022/2023 rules</MenuItem>
+        <MenuItem value={"cin2023_24"}>2023-2024 rules</MenuItem>
+      </Select>
+      </FormControl>
+    );
+  }
+
   const getValidationRulesSummary = () => {
     if (!validationRules) {
       return "";
@@ -316,6 +344,9 @@ const LoadData = (props: LoadDataPageProps) => {
         </Block>
         <Block spacing="blockLarge">
           <Box>{renderFileTabs()}</Box>
+        </Block>
+        <Block spacing="blockLarge">
+          <Box>{RulesetSelect()}</Box>
         </Block>
         <Block spacing="blockLarge">
           {validationRules && validationRules.length > 0 && (


### PR DESCRIPTION
fix #129

The wheel file needs to be updated so that the [latest version of rpc_main.py](https://github.com/data-to-insight/quality-lac-data-beta-validator/blob/refactor/migration/rpc_main.py#L27) (which is in the feat/run-903 branch) is available here. The latest wheel file can also always be gotten by building the [`refactor/migration` branch](https://github.com/data-to-insight/quality-lac-data-beta-validator/tree/refactor/migration) in the backend.

implemented:

- [x]  Added dropdown to frontend. 
- [x]  selected value can be gotten.

**Todo**
If the year 2022/23 is chosen, the string "lac2022_23" or "cin2022_23" respectively, needs to be passed in as a parameter to these functions:
- [x] pass in ruleset value to backend [when rules are run](https://github.com/data-to-insight/quality-lac-data-beta-validator/blob/f1354183037ec4a224af9d60130f045db4d60713/rpc_main.py#L63).
- [x] generate the choice of rules at the loading page based on the validation year that has been chosen. This requires passing  in the year value as a parameter to the[ `get_rules` function](https://github.com/data-to-insight/quality-lac-data-beta-validator/blob/f1354183037ec4a224af9d60130f045db4d60713/rpc_main.py#L27).

_How to check that it works._
By default, both of these functions are set to the lac2022_23 (or cin2022_23) year so passing in that string can be the first test as everything is expected to work. 

_side note_
The conversion from 2022/2023 to "lac2022_23" or "cin2022_23" can be implemented in the backend.